### PR TITLE
#1 Fixed ugly text overlapping in small screen

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,7 +34,7 @@ body{
 
 
 section{
-    min-width: 45em;
+    /*min-width: 45em;*/
     overflow: hidden;
 }
 
@@ -355,5 +355,10 @@ padding-bottom: 3em;
 }
 /* ---------------------------- */
 
-
+@media (max-width: 767px) {
+    .skill_item h4{
+        font-family: 'Work Sans', sans-serif;
+        font-size: 3.1vw;
+    }
+}
 


### PR DESCRIPTION
The grid items were responsive, on small screens the min-width was causing an issue with it not centering the grid items. 

For the overlapping text issue, the fix was to use viewport sized typography. 