### PR TITLE
Changed css of skills block to no static height and no static width

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -255,7 +255,7 @@ ul{
     color: black;
     margin: 1em; 
     padding: 1em;
-    height: 27em;
+    /*height: 27em;*/
     width: 100%;
     overflow: hidden;
 }
@@ -276,9 +276,9 @@ ul{
     float: left;
 }
 
-#front_end_card div{
+/*#front_end_card div{
     width: 50%;
-}
+}*/
 
 .skill_item_title{
     text-align: center;


### PR DESCRIPTION
The Issue of the items inside the skills block that didn't resize well as mentioned at the issues page "https://github.com/JasonHannanto/JasonHannanto.github.io/issues/1"  was because the static height and the 50% width given.  still 1 issue to fix is to make the blocks align nice next to each other horizontally on desktop size.